### PR TITLE
Properties and attribute access

### DIFF
--- a/demo/simple_demo.py
+++ b/demo/simple_demo.py
@@ -1,0 +1,42 @@
+# %%
+import datetime
+from pyprediktoredgeclient import hive
+test_hive = hive.Hive('Prediktor.ApisLoader.test')
+test_hive
+
+# %%
+mod_names = [mod.name for mod in test_hive.modules]
+for mod_name in mod_names:
+    print(mod_name)
+# %%
+if "testworker" in mod_names:
+    del test_hive['testworker']
+# %%
+
+test_module= test_hive.add_module('ApisWorker', 'testworker')
+# %%
+[item_type.Name for item_type in test_module.item_types]
+# %%
+for i in range(100):
+    new_item = test_module.add_item("Signal", f"TestItem{i}")
+    new_item.Amplitude=1
+    new_item.Bias = 1
+# %%
+print(test_module.items)
+# %%%
+example_item = test_module["TestItem10"]
+example_item.Value
+# %%
+try:
+    example_item.Value = 2.3
+    print("Fail, should not be allowed")
+except AttributeError:
+    print("OK, should not be allowed to set the value on a signalø")
+
+example_item.Waveform
+# %%
+some_items = [f"testworker.testitem{i}" for i in range(10, 40, 2)]
+for vqt in test_hive.get_values(some_items):
+    print(f"{vqt.item_id}: {vqt.value} ({vqt.quality}) @ {vqt.time.ToString()}")
+
+# %%

--- a/pyprediktoredgeclient/hive.py
+++ b/pyprediktoredgeclient/hive.py
@@ -1,5 +1,11 @@
+__all__ = 'Instances', 'Error', 'Hive', 'Module', 'Attr', 'Property', 'Item', 'ItemVQT'
+
 import pkg_resources
 import clr
+import functools
+import datetime
+import collections
+import System
 
 dlls = [
 	'HiveNetApi.dll',
@@ -31,6 +37,10 @@ import Prediktor
 def Instances():
 	return Prediktor.APIS.Hive.HiveInstanceService.GetRegisteredInstances()
 
+AttrFlags = Prediktor.APIS.Hive.Flags
+
+ItemVQT = collections.namedtuple('ItemVQT', 'item_id value quality time')
+
 class Error(Exception):
 	"""Generic exception used to report problems in Apis.py"""
 	def __init__(self, msg):
@@ -58,8 +68,9 @@ class Hive:
 		instance_name: optional name of the instance (default is None, i.e. the "ApisHive" instance)
 		server_name: optional name of the server hostting the instance (default is None, i.e. "localhost")
 		"""
-		self.api = Prediktor.APIS.Hive.Hive.CreateServer(instance_name, server_name)
+		self.api = Prediktor.APIS.Hive.Hive.CreateServer(instance_name, server_name or 'localhost')
 		self._modtypes = { str(obj):obj for obj in self.api.ModuleTypes }
+
 
 	def __str__(self):
 		return self.api.ConfigurationName
@@ -73,18 +84,23 @@ class Hive:
 	def __getitem__(self, key):
 		return self.get_module(key)
 
+	def __delitem__(self, key):
+		return self.get_module(key).delete()
+
 	def __iter__(self):
 		return self.api.GetModules()
 
+	@property
 	def modules(self):
 		"""Return a list containing all the modules in this hive instance"""
 		return [ Module(self, obj) for obj in self.api.GetModules() ]
 
 	def get_module(self, key):
 		"""Return the module with the specified name or index"""
-		objs = self.api.GetModules()
 		if isinstance(key, Module):
 			return key
+
+		objs = self.api.GetModules()
 
 		if isinstance(key, int):
 			return Module(self, objs[key])
@@ -97,25 +113,50 @@ class Hive:
 			raise Error("Invalid module name: ''".format(key))
 		raise Error("Invalid index type: {}".format(type(key).__name__))
 
-	def types(self):
+	@property
+	def module_types(self):
 		"""Return a list containing the name of all known module+types. These
 		names can be used as input to Hive.add_module().
 		"""
-		return [ obj for obj in self.api.ModuleTypes ]
+		return list(self.api.ModuleTypes)
 
-	def add_module(self, type, name=None):
+
+	def add_module(self, module_type, name=None):
 		"""Create and return a new Hive.Module in the Hive.
 
 		Arguments:
 		type: the name of a module type
 		name: the name of the new module (default is None, i.e. use a generated name based on moduletype)
 		"""
+		if isinstance(module_type, str):
+			for mt in self.module_types:
+				if mt.ClassName == module_type:
+					module_type = mt
+					break
+			else:
+				raise ValueError(f"Unknown module type {module_type}")
+
 		if name is not None:
-			type.set_InstanceName(name)
-		obj = self.api.AddModule(type)
+			module_type.set_InstanceName(name)
+		obj = self.api.AddModule(module_type)
 		return Module(self, obj)
 
+	def get_values(self, items, since=None):
+		if not since:
+			since = System.DateTime.MinValue
+		itemIds = [i.item_id if isinstance(i, Item) else str(i) for i in items]
+		handles = self.api.LookupItemHandles(itemIds)
 
+		h_out = System.Array[System.Int32]([])
+		v_out = System.Array[System.Object]([])
+		q_out = System.Array[System.UInt16]([])
+		t_out = System.Array[System.DateTime]([])
+		err_out =  System.Array[System.Int32]([])
+		check_out = System.Boolean(False)
+		last_read=System.DateTime.Now
+
+		void, h, v, q, t, err, check, tor = self.api.ReadItems(since, handles,  h_out, v_out, q_out, t_out, err_out, check_out, last_read)
+		return [ItemVQT(itemIds[i], v[i], q[i], t[i]) for i in range(len(h))]
 
 class Module:
 	"""Class used to access a specific module in an ApisHive instance. The
@@ -127,7 +168,7 @@ class Module:
 		self.api = api
 
 	def __str__(self):
-		return self.name()
+		return self.name
 
 	def __repr__(self):
 		return "<Apis.Hive.Module: >".format(self)
@@ -138,15 +179,20 @@ class Module:
 	def __getitem__(self, key):
 		return self.get_item(key)
 
+	def __delitem__(self, key):
+		self.get_item(key).api.DeleteItem()
+
 	def __iter__(self):
 		return self.api.GetItems()
 
+	@property
 	def name(self):
 		return self.api.Name
 
+	@property
 	def items(self):
 		"""Return a list containing all the items in this module"""
-		return [ Item(self, obj) for obj in self.api.GetItems() ]
+		return [ Item(self, obj) for obj in list(self.api.GetItems()) ]
 
 	def get_item(self, key):
 		"""Return the item with the specified name or index"""
@@ -164,6 +210,33 @@ class Module:
 
 		raise Error("Invalid index type: {}".format(type(key).__name__))
 
+	@property
+	def item_types(self):
+		"""Return the available item types for this  module"""
+		return list(self.api.GetItemTypes())
+
+
+	def add_item(self, item_type, item_name):
+		"""Add a new item to the hive"""
+		if isinstance(item_type, str):
+			for it in self.item_types:
+				if it.Name==item_type:
+					item_type = it
+					break
+			else:
+				raise ValueError(f"unknown item type {item_type}")
+		
+		template = it.GetNewItemTemplate(item_name)
+		item, item_error, attr_error, check = self.api.AddItems([template], None, None, None)
+		if check:
+			for i, a_e in enumerate(attr_error):
+				if a_e > 0:
+					t_attr = template.Attributes[i]
+					raise Error(f"Error setting {t_attr.Name}")
+
+		return Item(self, item[0])
+
+	@property
 	def properties(self):
 		return [ Property(self, obj) for obj in self.api.GetProperties() ]
 
@@ -201,48 +274,61 @@ class Property:
 
 class Item:
 	def __init__(self, module, api):
-		self.module = module
-		self.api = api
+		super().__setattr__('module', module)
+		super().__setattr__('api', api)
+		# self.module = module
+		# self.api = api
 
 	def __str__(self):
-		return self.name()
+		return self.name
 
 	def __repr__(self):
-		return "<Apis.Hive.Module.Property: >".format(self)
+		return f"<Apis.Hive.Module.Item: {self.name}>"
 
 	def __len__(self):
-		return len(self.api.GetAttributes())
+		return len(self.attr)
 
 	def __getitem__(self, key):
-		return self.get_attr(key)
+		return self.get_attr(key).value
+
+	__getattr__ = __getitem__
+
+	def __setitem__(self, key, value):
+		attr = self.get_attr(key)
+		attr.value = value
+
+	def __setattr__(self, key, value):
+		try:
+			attr = self.get_attr(key)
+			attr.value = value
+
+		except Error:
+			super().__setattr__(key, value)
 
 	def __iter__(self):
 		return self.api.GetAttributes()
 
+	@property
 	def name(self):
 		return self.api.Name
 
-	def value(self):
-		return self['Value'].value()
+	@property
+	def item_id(self):
+		return self.api.ItemID
 
-	def attrs(self):
-		return [ Attr(self, obj) for obj in self.api.GetAttributes() ]
 
 	def get_attr(self, key):
 		"""Return the attr with the specified name or index"""
 		if isinstance(key, Attr):
 			return key
-
+		if isinstance(key, str):
+			for attr in self.api.GetAttributes():
+				if attr.Name == key:
+					return Attr(self, attr)
 		if isinstance(key, int):
 			return Attr(self, self.api.GetAttributes()[key])
+		raise Error(f"Invalid index: {repr(key)}")
 
-		if isinstance(key, str):
-			for obj in self.api.GetAttributes():
-				if obj.Name == key:
-					return Attr(self, obj)
-			raise Error("Invalid attribute name: '{}'".format(key))
-
-		raise Error("Invalid index type: {}".format(type(key).__name__))
 
 
 class Attr:
@@ -251,13 +337,51 @@ class Attr:
 		self.api = api
 
 	def __str__(self):
-		return "{}={}".format(self.name(), self.value())
+		return "{}={}".format(self.name, self.value)
 
 	def __repr__(self):
 		return "<Apis.Hive.Module.Attr: {}>".format(self)
 
+	@property
 	def name(self):
 		return self.api.Name
 
-	def value(self):
-		return self.api.Value
+	@property
+	def flag(self):
+		return self.api.Flag
+
+	
+
+	def get_value(self):
+		v = self.api.Value
+		if self.flag & AttrFlags.Enumerated:
+			attr_enum = self.api.GetEnumeration()
+			for i,val in enumerate(attr_enum.Values):
+				if val==v:
+					return attr_enum.Names[i]
+			raise Error(f"Enumerated property not found")
+		return v
+
+	def set_value(self, value):
+		if self.flag & AttrFlags.ReadOnly:
+			print(f'should fail, {self.flag}')
+			raise AttributeError(f"Attribute {self.name} on {self.item} is read only")
+
+		if self.flag & AttrFlags.Enumerated:
+			attr_enum = self.api.GetEnumeration()
+			for i,val in enumerate(attr_enum.Names):
+				if str(val)==value:
+					self.api.Value = attr_enum.Values[i]
+					break
+			else:
+				raise Error(f"Enumerated property not found")
+		else:
+			try:
+				self.api.Value = value
+			except Exception as e:
+				raise Error(f"Exception from Apis {e}")
+
+
+	value = property(get_value, set_value, doc="Access the property value")
+
+

--- a/requirements.py
+++ b/requirements.py
@@ -1,2 +1,1 @@
 # do not add anything here. See setup.py
--e .

--- a/requirements.py
+++ b/requirements.py
@@ -1,1 +1,2 @@
 # do not add anything here. See setup.py
+-e


### PR DESCRIPTION
Dette er da en mega-innsjekking. Beklager det. 

1. @property på endel ting jeg tenker skal være read-only properties på hiver/moduler/items etc
2. Direkte oppslag på attribute.value fra items dvs at man kan ha kode som:
    t=myitem.Time
    v=myItem.Value
    otheritem.Value = 2*v
3. Begynnelsen på eksempelmoduler
4. Direkte uthenting av sett av VQT-verdier fra Hive (rask tilgang)
5. Noen ekstra attributter på items etc. F.eks item_id
6. begrensing av eksporterte symboler (__all__)
7. add_module(self, type, name=None) => add_module(self, **module_type**, name=None) Siden 'type' er et globalt symbol
8. lagt til _module.add_item_
9. lagt til _del module['item']_
10. Det er mulig å skrive verdier til item-attr
11. Item-attr forstår enumererte verdier og returnerer enumerasjonsverdien. 
   