### PR TITLE
import from Apis install dir on windows

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+v0.6.0
+ - Flexible import of APISlibraries on win32. 
+
 v0.5.0
 - Added externalitem support
 - Direct property access to modules

--- a/examples/notebooks/comprehensive.ipynb
+++ b/examples/notebooks/comprehensive.ipynb
@@ -78,6 +78,8 @@
    },
    "outputs": [],
    "source": [
+    "import sys\n",
+    "sys.path.append( r'C:\\Users\\LocalUser\\Source\\Repos\\PyPrediktorEdgeClient')\n",
     "from pyprediktoredgeclient import hiveservices"
    ]
   },
@@ -100,6 +102,7 @@
       "text/plain": [
        "[UUID('51f92300-ca68-11d2-85c3-0000e8404a66'),\n",
        " UUID('04d4eb61-ccd3-43cc-a4ca-d2b5c4c56b05'),\n",
+       " UUID('72dfd4a1-f484-4e8c-9818-64e17c7ddbaf'),\n",
        " UUID('8322407c-ea3d-4886-9d99-cc8ccd35da6f'),\n",
        " UUID('8840f50b-924d-4429-bc52-d67840169db8'),\n",
        " UUID('f84849c5-e05e-4666-a290-5792b0448a50')]"
@@ -143,6 +146,9 @@
       "\n",
       "ScadaInput\n",
       "\tFalse\t04d4eb61-ccd3-43cc-a4ca-d2b5c4c56b05\tPrediktor.ApisLoader.ScadaInput\n",
+      "\n",
+      "pytestinstance\n",
+      "\tTrue\t72dfd4a1-f484-4e8c-9818-64e17c7ddbaf\tPrediktor.ApisLoader.pytestinstance\n",
       "\n",
       "Kontornett\n",
       "\tFalse\t8322407c-ea3d-4886-9d99-cc8ccd35da6f\tPrediktor.ApisLoader.Kontornett\n",
@@ -280,7 +286,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "'pytestinstance' instance was stopped, starting\n"
+      "'pytestinstance' instance is running\n"
      ]
     }
    ],
@@ -547,6 +553,45 @@
     "time.sleep(1.0)     #Let APIS propagate the values\n",
     "assert func['Value'] == 8.5"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# hiveservices revisited - deleting a hive"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pytestinstance.running = False\n",
+    "\n",
+    "hiveservices.remove_instance(pytestinstance)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'C:\\\\Program Files\\\\APIS\\\\Bin64'"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pyprediktoredgeclient import util\n",
+    "util.importlocation"
+   ]
   }
  ],
  "metadata": {
@@ -568,7 +613,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.5"
   },
   "orig_nbformat": 4
  },

--- a/examples/simple/hiveservices_example.py
+++ b/examples/simple/hiveservices_example.py
@@ -18,11 +18,11 @@ for instance in instance_list:
 # %% Grag the instance 'test' and  turn it on and then off (or visa-versa)
 pytestinstance = hiveservices.get_instance('pytestinstance')
 
-runstate = test.running
-test.running = not runstate
+runstate = pytestinstance.running
+pytestinstance.running = not runstate
 time.sleep(1.5)
-assert test.running != runstate
-test.running = runstate
+assert pytestinstance.running != runstate
+pytestinstance.running = runstate
 
 
 # %%

--- a/pyprediktoredgeclient/hive.py
+++ b/pyprediktoredgeclient/hive.py
@@ -207,7 +207,6 @@ class Module:
 	def __iter__(self):
 		return self.api.GetItems()
 
-
 	def __getattr__(self, key):
 		self.get_property(key).value
 
@@ -217,7 +216,6 @@ class Module:
 			prop.value = value
 		except Error:
 			super().__setattr__(key, value)
-
 
 	@property
 	def name(self):
@@ -293,7 +291,6 @@ class Property(BaseAttribute):
 
 	def __repr__(self):
 		return f"<Apis.Hive.Module.Property: {self}>"
-
 
 class Item:
 	def __init__(self, module, api):

--- a/pyprediktoredgeclient/hiveservices.py
+++ b/pyprediktoredgeclient/hiveservices.py
@@ -46,7 +46,7 @@ def get_instance(name):
     """
     return HiveInstance(_get_instance(_create_instance_service(), name))    
 
-def remove_instance(inst):
+def remove_instance(instance):
     """
     Remove an instance.
 
@@ -54,13 +54,9 @@ def remove_instance(inst):
     inst: string or HiveInstance. the instance that should be removed
     """
     service = _create_instance_service()
-
-    if isinstance(inst, str):
-        inst = _get_instance(service, inst)
-    elif isinstance(inst, HiveInstance):
-        raise Error('Unsupported type for instance lookup')
-
-    service.RemoveInstance(inst.CLSID)
+    instance_name = instance.name if isinstance(instance, HiveInstance) else instance
+    instance = _get_instance(service, instance_name)
+    service.RemoveInstance(instance.CLSID)
 
 def add_instance(name, as_service=True):
     """

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     package_data={
         "": ["dlls/*.dll"]
     },
-    version='0.5.0',
+    version='0.6.0',
     description='A Python library to talk to Prediktor APIS/EDGE',
     author='Prediktor',
     license='MIT'

--- a/todo.md
+++ b/todo.md
@@ -8,7 +8,7 @@
 - [x] Set/get external_items
 - [x] Add attributes to items
 - [x] Get global-attributes from an Hive
-- [ ] Flexible loading of Apis-dlls
+- [x] Flexible loading of Apis-dlls
 - [ ] honeystore
 - [ ] timeseries
 - [ ] More demo cases


### PR DESCRIPTION
Flexible import of APISlibraries on win32. If the client library is running on win32 and a Hive install was detected in 
Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Prediktor\Apis\HiveInstallRoot an attempt is made to import from this location. Otherwise a normal import is attempted.
