### PR TITLE
Improved timestamp handling

### DIFF
--- a/examples/notebooks/comprehensive.ipynb
+++ b/examples/notebooks/comprehensive.ipynb
@@ -558,6 +558,78 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Setting and getting several items at once\n",
+    "It is possible to set several items at once, using the hive.set_values and hive.get_values methods. This is probably the fastest way to set many values at once. In the example below we use the `ItemVQT.from_dict` method to construct a sequence of items that are passed to the `.set_values` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyprediktoredgeclient.util import ItemVQT\n",
+    "from datetime import datetime\n",
+    "\n",
+    "vals = {'testworker.var1':2.0, 'testworker.var2':12.0}\n",
+    "vqt = ItemVQT.from_dict(vals, time='2022-03-24 01:00')       #make a list of ItemVQT\n",
+    "test_hive.set_values(vqt)\n",
+    "\n",
+    "time.sleep(1.0)     #Let APIS propagate the values\n",
+    "\n",
+    "assert func.value == 14\n",
+    "assert func.time == datetime(2022, 3, 24, 1, 0,0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is also possible to read several values at once from different modules using the `.get_values` method on the hive. This method returns a sequence of `ItemVQT` objects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "readvals = test_hive.get_values(['testworker.var1', 'testworker.var2'])\n",
+    "\n",
+    "dict_vals = dict((i.item_id, i.value) for i in readvals)  #transform the list of ItemVQT to a dict\n",
+    "\n",
+    "assert dict_vals['testworker.var1'] == 2.0 and dict_vals['testworker.var2'] == 12.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Datetime attributes\n",
+    "\n",
+    "Item attributes that have a datetime type (i.e. item.time) can be set either using a Python datetime.datetime or using an ISO8601 formatted string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test2_var = test_module2.add_item(\"variable\", \"item1\", value=1.0, time=\"2022-03-22 06:00\")\n",
+    "assert test2_var.time == datetime(2022, 3, 22, 6, 0)\n",
+    "\n",
+    "test2_var.time = datetime(2022, 3, 22, 8, 0)\n",
+    "assert test2_var.time == datetime(2022, 3, 22, 8, 0)\n",
+    "\n",
+    "test2_var.time = \"2022-03-22 10:00\"\n",
+    "assert test2_var.time == datetime(2022, 3, 22, 10, 0)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Adding a logger module"
    ]
   },


### PR DESCRIPTION
Several improvements and bug-fixes related to setting of item values, and time-values in particular

- All "timestamp" type attributes and properties on items and modules are now exposed as python datetime.datetime 
- timestamp type values can be set with an datetime.datetime object or with an ISO8601 formatted string
- Several items can be set at once with the hive.set_values() method. This method accepts a list of `ItemVQT` values
- Several items can be retrived at once with the `hive.get_values()` method. This method accepts a list of Itemnames and returns a list of `ItemVQT` values
- The `ItemVQT.from_dict()` static method can be used to construct a list of ItemVQT-values from a dictionary 

Bugfixes:
- The `fm_pydatetime()` function returned None. Returns the right data type now

As always: Examples of usage can be found in the `comprehensive.ipynb` Jupyter notebook